### PR TITLE
feat: showmigrations task, argument for migrate

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -34,10 +34,13 @@ def runapiworker(c):
         c.run(f"python {manage_py} runserver 0.0.0.0:8880")
 
 
-@task
-def celery(c):
+@task(help={"purge": "Delete all heltour tasks."})
+def celery(c, purge=False):
     """Run Celery worker for background tasks."""
-    c.run("celery -A heltour worker -l info", pty=True)
+    if purge:
+        c.run("celery -A heltour purge")
+    else:
+        c.run("celery -A heltour worker -l info", pty=True)
 
 
 @task(

--- a/tasks.py
+++ b/tasks.py
@@ -47,14 +47,11 @@ def celery(c, purge=False):
     optional=["app"],
     help={"app": "Optionally specify app or specific migration, e.g. 'invoke migrate -a \"tournament 0001\"'"},
 )
-def migrate(c, app=None):
+def migrate(c, app=""):
     """Run Django database migrations."""
     manage_py = project_relative("manage.py")
     migrate_cmd = f"python {manage_py} migrate"
-    if app:
-        c.run(f"{migrate_cmd} {app}")
-    else:
-        c.run(migrate_cmd)
+    c.run(f"{migrate_cmd} {app}")
 
 
 @task
@@ -68,14 +65,11 @@ def makemigrations(c):
     optional=["app"],
     help={"app": "Optionally specify app."}
 )
-def showmigrations(c, app=None):
+def showmigrations(c, app=""):
     """Show Django database migrations."""
     manage_py = project_relative("manage.py")
     show_cmd = f"python {manage_py} showmigrations"
-    if app:
-        c.run(f"{show_cmd} {app}")
-    else:
-        c.run(show_cmd)
+    c.run(f"{show_cmd} {app}")
 
 
 @task

--- a/tasks.py
+++ b/tasks.py
@@ -40,11 +40,18 @@ def celery(c):
     c.run("celery -A heltour worker -l info", pty=True)
 
 
-@task
-def migrate(c):
+@task(
+    optional=["app"],
+    help={"app": "Optionally specify app or specific migration, e.g. 'invoke migrate -a \"tournament 0001\"'"},
+)
+def migrate(c, app=None):
     """Run Django database migrations."""
     manage_py = project_relative("manage.py")
-    c.run(f"python {manage_py} migrate")
+    migrate_cmd = f"python {manage_py} migrate"
+    if app:
+        c.run(f"{migrate_cmd} {app}")
+    else:
+        c.run(migrate_cmd)
 
 
 @task
@@ -52,6 +59,20 @@ def makemigrations(c):
     """Create new Django migrations."""
     manage_py = project_relative("manage.py")
     c.run(f"python {manage_py} makemigrations")
+
+
+@task(
+    optional=["app"],
+    help={"app": "Optionally specify app."}
+)
+def showmigrations(c, app=None):
+    """Show Django database migrations."""
+    manage_py = project_relative("manage.py")
+    show_cmd = f"python {manage_py} showmigrations"
+    if app:
+        c.run(f"{show_cmd} {app}")
+    else:
+        c.run(show_cmd)
 
 
 @task


### PR DESCRIPTION
needed to specify a migration, so quickly added that to `tasks.py`. i assume this could be done differently/better, open to changes.

edit: also adds a flag to celery to delete heltour tasks, because i can never remember the command otherwise.