### PR TITLE
add back in single line that went missing from commit 40d62f6

### DIFF
--- a/heltour/tournament/tasks.py
+++ b/heltour/tournament/tasks.py
@@ -601,7 +601,7 @@ def _init_start_league_games(
     round_ = Round.objects.filter(
         season__league=league, is_completed=False, publish_pairings=True
     ).first()
-    signals.do_update_broadcast_round.send(sender="start_games", round_=round_)
+    signals.do_update_broadcast_round.send(sender="start_games", round_id=round_.pk)
     return result
 
 


### PR DESCRIPTION
this line from a [previous commit ](https://github.com/Lichess4545/litour/commit/40d62f62ef3c5b45710476a8f5bb5531f35f36bf) somehow went missing later (probably during a merge?) – add it back in. everything else from said commit seems to be still around.